### PR TITLE
Fix problem where qgrid does not display in Jupyter notebook

### DIFF
--- a/clean.ipynb
+++ b/clean.ipynb
@@ -15,6 +15,7 @@
    "source": [
     "# !pip install qgrid\n",
     "# !jupyter nbextension enable --py --sys-prefix qgrid"
+    "# !jupyter nbextension enable --py widgetsnbextension"
    ]
   },
   {


### PR DESCRIPTION
Instructions:

1. Run the following code block (install, nbextension enable).

```
!pip install qgrid
!jupyter nbextension enable --py --sys-prefix qgrid
!jupyter nbextension enable --py widgetsnbextension
```
2. Restart Jupyter Notebook Server

